### PR TITLE
fix assumes statement

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: sosumi
 base: core18
-assumes: 2.43
+assumes:
+        - snapd2.43
 version: '0.666'
 summary: Download and install macOS in a VM
 description: |


### PR DESCRIPTION
Avoid getting this message:
`Sorry, an error occurred in Snapcraft: 'float' object is not iterable `
when running snapcraft