### PR TITLE
Iss26

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 name: sosumi
 base: core18
-assumes: 2.43
+assumes:
+        - snapd2.43
 version: '0.666'
 summary: Download and install macOS in a VM
 description: |

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,6 +42,7 @@ apps:
       - unity7
       - wayland
       - desktop
+      - removable-media
 
 parts:
   sosumi:


### PR DESCRIPTION
Fix for issue #26 
Enables accessing other partitions in /mnt, /media and /run/media
To enable it, after sosumi is installed:
`snap connect sosumi:removable-media`
Or in Ubuntu Software:
![image](https://user-images.githubusercontent.com/10415894/87325142-5e09ee80-c531-11ea-9f11-f374eae73962.png)

